### PR TITLE
StandardCyborgUI: Add `onRenderedPointCloudImageReady` hook in PointCloudPreviewViewController 

### DIFF
--- a/StandardCyborgUI/StandardCyborgUI/PointCloudPreviewViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/PointCloudPreviewViewController.swift
@@ -68,8 +68,8 @@ import UIKit
         as soon as the view controller's view appears */
     @objc public private(set) var renderedPointCloudImage: UIImage?
 
-    /** Gives us a hook into the VC lifecycle where we can reliably get renderedPointCloudImage. */
-    @objc public var onViewDidAppear: ((PointCloudPreviewViewController) -> Void)?
+    /** Gives us a hook to capture the renderedPointCloudImage separate from when it may be set. */
+    @objc public var onRenderedPointCloudImageReady: ((UIImage) -> Void)?
 
     // MARK: - UIViewController
     
@@ -98,7 +98,7 @@ import UIKit
     
     override public func viewDidAppear(_ animated: Bool) {
         self.renderedPointCloudImage = self.sceneView.snapshot()
-        onViewDidAppear?(self)
+        onRenderedPointCloudImageReady?(self.renderedPointCloudImage!)
     }
     
     override public func viewDidLayoutSubviews() {

--- a/StandardCyborgUI/StandardCyborgUI/PointCloudPreviewViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/PointCloudPreviewViewController.swift
@@ -67,7 +67,10 @@ import UIKit
     /** A snapshot of the point cloud as rendered, which becomes available
         as soon as the view controller's view appears */
     @objc public private(set) var renderedPointCloudImage: UIImage?
-    
+
+    /** Gives us a hook into the VC lifecycle where we can reliably get renderedPointCloudImage. */
+    @objc public var onViewDidAppear: ((PointCloudPreviewViewController) -> Void)?
+
     // MARK: - UIViewController
     
     override public func viewDidLoad() {
@@ -95,6 +98,7 @@ import UIKit
     
     override public func viewDidAppear(_ animated: Bool) {
         self.renderedPointCloudImage = self.sceneView.snapshot()
+        onViewDidAppear?(self)
     }
     
     override public func viewDidLayoutSubviews() {


### PR DESCRIPTION
_Please review after https://github.com/StandardCyborg/StandardCyborgCocoa/pull/2._

This hook will allow consumers of PointCloudPreviewViewController to reliably access `renderedPointCloudImage` since that prop is set in viewDidAppear.

This was an issue for the case where the view controller was added as a child view controller.