### PR TITLE
StandardCyborgUI: Fixes podspec resource bundle reference

### DIFF
--- a/StandardCyborgUI/StandardCyborgUI.podspec
+++ b/StandardCyborgUI/StandardCyborgUI.podspec
@@ -28,7 +28,8 @@ Pod::Spec.new do |s|
   s.requires_arc      = true
   s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}" }
   s.source_files      = "StandardCyborgUI/**/*.{h,swift,metal}"
-  s.resources         = ['StandardCyborgUI/StandardCyborgUI/Assets.xcassets', 'StandardCyborgUI/StandardCyborgUI/*.scn']
+  s.resources         = ['StandardCyborgUI/*.scn']
+  s.resource_bundles  = { "StandardCyborgUI" => ['StandardCyborgUI/Assets.xcassets']}
   s.weak_frameworks   = "StandardCyborgFusion", "QuartzCore", "CoreVideo"
   s.dependency          "StandardCyborgFusion", "~> #{s.version}"
 

--- a/StandardCyborgUI/StandardCyborgUI.podspec
+++ b/StandardCyborgUI/StandardCyborgUI.podspec
@@ -28,8 +28,7 @@ Pod::Spec.new do |s|
   s.requires_arc      = true
   s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}" }
   s.source_files      = "StandardCyborgUI/**/*.{h,swift,metal}"
-  s.resources         = ['StandardCyborgUI/*.scn']
-  s.resource_bundles  = { "StandardCyborgUI" => ['StandardCyborgUI/Assets.xcassets']}
+  s.resources         = ['StandardCyborgUI/*.scn', 'StandardCyborgUI/Assets.xcassets']
   s.weak_frameworks   = "StandardCyborgFusion", "QuartzCore", "CoreVideo"
   s.dependency          "StandardCyborgFusion", "~> #{s.version}"
 

--- a/StandardCyborgUI/StandardCyborgUI.xcodeproj/project.pbxproj
+++ b/StandardCyborgUI/StandardCyborgUI.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7642B7E521E55E9A00BC45C7 /* DefaultScanningViewRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7642B7E421E55E9A00BC45C7 /* DefaultScanningViewRenderer.swift */; };
 		7642B82721E69FC900BC45C7 /* StandardCyborgFusion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7620D26B21CE0A89008D0095 /* StandardCyborgFusion.framework */; };
 		7642B82F21E6BA6C00BC45C7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7642B82E21E6BA6C00BC45C7 /* Assets.xcassets */; };
+		A080752F22D3B3FF00D1CFD8 /* Bundle+SCUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A080752E22D3B3FF00D1CFD8 /* Bundle+SCUI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 		7642B7E021E55E6100BC45C7 /* PointCloudPreviewViewController.scn */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = PointCloudPreviewViewController.scn; sourceTree = "<group>"; };
 		7642B7E421E55E9A00BC45C7 /* DefaultScanningViewRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultScanningViewRenderer.swift; sourceTree = "<group>"; };
 		7642B82E21E6BA6C00BC45C7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A080752E22D3B3FF00D1CFD8 /* Bundle+SCUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+SCUI.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 				7620D25F21CDADA5008D0095 /* PointCloudCommandEncoder.metal */,
 				7642B7E021E55E6100BC45C7 /* PointCloudPreviewViewController.scn */,
 				7642B7DF21E55E6100BC45C7 /* PointCloudPreviewViewController.swift */,
+				A080752E22D3B3FF00D1CFD8 /* Bundle+SCUI.swift */,
 			);
 			path = StandardCyborgUI;
 			sourceTree = "<group>";
@@ -194,6 +197,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7642B7D321E455AB00BC45C7 /* ShutterButton.swift in Sources */,
+				A080752F22D3B3FF00D1CFD8 /* Bundle+SCUI.swift in Sources */,
 				7620D26421CDADA5008D0095 /* ScanningViewRenderer.swift in Sources */,
 				7620D25B21CDAD69008D0095 /* ScanningHapticFeedbackEngine.swift in Sources */,
 				7642B7E521E55E9A00BC45C7 /* DefaultScanningViewRenderer.swift in Sources */,

--- a/StandardCyborgUI/StandardCyborgUI/Bundle+SCUI.swift
+++ b/StandardCyborgUI/StandardCyborgUI/Bundle+SCUI.swift
@@ -3,5 +3,5 @@ import Foundation
 extension Bundle {
     // Any entity using this prop should exist in the same target as the Bundle(for:) argument otherwise its contents
     // won't be packaged correctly.
-    static let scuiBundle = Bundle(url: Bundle(for: ShutterButton.self).url(forResource: "StandardCyborgUI", withExtension: "bundle")!)!
+    static let scuiBundle = Bundle(for: ShutterButton.self)
 }

--- a/StandardCyborgUI/StandardCyborgUI/Bundle+SCUI.swift
+++ b/StandardCyborgUI/StandardCyborgUI/Bundle+SCUI.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Bundle {
+    // Any entity using this prop should exist in the same target as the Bundle(for:) argument otherwise its contents
+    // won't be packaged correctly.
+    static let scuiBundle = Bundle(url: Bundle(for: ShutterButton.self).url(forResource: "StandardCyborgUI", withExtension: "bundle")!)!
+}

--- a/StandardCyborgUI/StandardCyborgUI/ScanningViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ScanningViewController.swift
@@ -260,9 +260,7 @@ import UIKit
     }
     
     // MARK: - Private properties
-    
-    private lazy var _bundle = Bundle(for: ScanningViewController.self)
-    
+        
     private let _metalDevice = MTLCreateSystemDefaultDevice()!
     private lazy var _algorithmCommandQueue = _metalDevice.makeCommandQueue()!
     private lazy var _visualizationCommandQueue = _metalDevice.makeCommandQueue()!
@@ -319,7 +317,7 @@ import UIKit
         _scanFailedLabel.backgroundColor = UIColor(white: 1.0, alpha: 0.8)
         _scanFailedLabel.isHidden = true
         
-        dismissButton.setImage(UIImage(named: "Dismiss", in: _bundle, compatibleWith: nil), for: UIControl.State.normal)
+        dismissButton.setImage(UIImage(named: "Dismiss", in: Bundle.scuiBundle, compatibleWith: nil), for: UIControl.State.normal)
         dismissButton.addTarget(self, action: #selector(dismissTapped(_:)), for: UIControl.Event.touchUpInside)
         shutterButton.addTarget(self, action: #selector(shutterTapped(_:)), for: UIControl.Event.touchUpInside)
         

--- a/StandardCyborgUI/StandardCyborgUI/ShutterButton.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ShutterButton.swift
@@ -44,11 +44,10 @@ import UIKit
     
     // MARK: - Private
     
-    private static let _bundle = Bundle(for: ShutterButton.self)
     private var _imageForState: [ShutterButtonState: UIImage] = [
-        .default: UIImage(named: "ShutterButton", in: _bundle, compatibleWith: nil)!,
-        .countdown: UIImage(named: "ShutterButton-Selected", in: _bundle, compatibleWith: nil)!,
-        .scanning: UIImage(named: "ShutterButton-Recording", in: _bundle, compatibleWith: nil)!,
+        .default: UIImage(named: "ShutterButton", in: Bundle.scuiBundle, compatibleWith: nil)!,
+        .countdown: UIImage(named: "ShutterButton-Selected", in: Bundle.scuiBundle, compatibleWith: nil)!,
+        .scanning: UIImage(named: "ShutterButton-Recording", in: Bundle.scuiBundle, compatibleWith: nil)!,
     ]
     
     private func _updateButtonImage() {


### PR DESCRIPTION
_Please review after #2._

This PR fixes an issue where references to the asset bundle embedded in StandardCyborgUI would crash due to the asset bundle not being correctly referenced in the podspec.

This PR also DRYs up the calls to the framework's bundle by adding an extension on `Bundle` exposing a static prop which abstracts the logic for referencing the Bundle.