### PR TITLE
StandardCyborgNetworking: Adds support for API v2

### DIFF
--- a/StandardCyborgNetworking/StandardCyborgNetworking.xcodeproj/project.pbxproj
+++ b/StandardCyborgNetworking/StandardCyborgNetworking.xcodeproj/project.pbxproj
@@ -9,32 +9,31 @@
 /* Begin PBXBuildFile section */
 		76122BEA21EC2AFD00D887DF /* ServerUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76122BE921EC2AFD00D887DF /* ServerUser.swift */; };
 		76122BEC21EC2B3A00D887DF /* ServerCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76122BEB21EC2B3A00D887DF /* ServerCustomer.swift */; };
-		76122BEE21EC32F200D887DF /* ServerScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76122BED21EC32F200D887DF /* ServerScan.swift */; };
 		76122BF221ED041500D887DF /* ServerOperationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76122BF121ED041500D887DF /* ServerOperationError.swift */; };
-		76122BF621ED087300D887DF /* MappableServerCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76122BF521ED087300D887DF /* MappableServerCustomer.swift */; };
 		7623165C21EDB0E5004D1AFB /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7623165A21EDB0E5004D1AFB /* ObjectMapper.framework */; };
 		7623165D21EDB0E5004D1AFB /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7623165B21EDB0E5004D1AFB /* PromiseKit.framework */; };
 		7623166421EDB40F004D1AFB /* ZipArchive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7623166321EDB40F004D1AFB /* ZipArchive.framework */; };
 		7623166621EDBD2D004D1AFB /* PMKFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7623166521EDBD2D004D1AFB /* PMKFoundation.framework */; };
 		76E7E14121E95C140038C9E0 /* StandardCyborgNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 76E7E13F21E95C140038C9E0 /* StandardCyborgNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		76E7E15121E95C5B0038C9E0 /* ServerUserOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14721E95C590038C9E0 /* ServerUserOperations.swift */; };
-		76E7E15221E95C5B0038C9E0 /* MappableServerScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14821E95C5A0038C9E0 /* MappableServerScan.swift */; };
 		76E7E15321E95C5B0038C9E0 /* ServerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14921E95C5A0038C9E0 /* ServerAPIClient.swift */; };
 		76E7E15421E95C5B0038C9E0 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14A21E95C5A0038C9E0 /* MD5.swift */; };
 		76E7E15521E95C5B0038C9E0 /* DefaultServerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14B21E95C5A0038C9E0 /* DefaultServerAPIClient.swift */; };
 		76E7E15621E95C5B0038C9E0 /* ServerSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14C21E95C5A0038C9E0 /* ServerSyncEngine.swift */; };
 		76E7E15721E95C5B0038C9E0 /* ServerScanOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14D21E95C5A0038C9E0 /* ServerScanOperations.swift */; };
-		76E7E15821E95C5B0038C9E0 /* MappableServerUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14E21E95C5A0038C9E0 /* MappableServerUser.swift */; };
 		76E7E15921E95C5B0038C9E0 /* ServerCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E14F21E95C5A0038C9E0 /* ServerCredentials.swift */; };
 		76E7E15A21E95C5B0038C9E0 /* DateTimeTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E7E15021E95C5A0038C9E0 /* DateTimeTransform.swift */; };
+		A0C582DD22D553D70090FF6A /* ServerAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C582DC22D553D70090FF6A /* ServerAccessToken.swift */; };
+		A0C582E122D553E10090FF6A /* ServerScanAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C582DE22D553E10090FF6A /* ServerScanAttachment.swift */; };
+		A0C582E322D553E10090FF6A /* ServerTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C582E022D553E10090FF6A /* ServerTeam.swift */; };
+		A0C582E522D553EC0090FF6A /* ServerScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C582E422D553EC0090FF6A /* ServerScan.swift */; };
+		A0C582E722D553F90090FF6A /* Coding+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C582E622D553F90090FF6A /* Coding+Util.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		76122BE921EC2AFD00D887DF /* ServerUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerUser.swift; sourceTree = "<group>"; };
 		76122BEB21EC2B3A00D887DF /* ServerCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerCustomer.swift; sourceTree = "<group>"; };
-		76122BED21EC32F200D887DF /* ServerScan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerScan.swift; sourceTree = "<group>"; };
 		76122BF121ED041500D887DF /* ServerOperationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerOperationError.swift; sourceTree = "<group>"; };
-		76122BF521ED087300D887DF /* MappableServerCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappableServerCustomer.swift; sourceTree = "<group>"; };
 		7623165A21EDB0E5004D1AFB /* ObjectMapper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ObjectMapper.framework; path = Carthage/Build/iOS/ObjectMapper.framework; sourceTree = "<group>"; };
 		7623165B21EDB0E5004D1AFB /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		7623166321EDB40F004D1AFB /* ZipArchive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZipArchive.framework; path = Carthage/Build/iOS/ZipArchive.framework; sourceTree = "<group>"; };
@@ -43,15 +42,18 @@
 		76E7E13F21E95C140038C9E0 /* StandardCyborgNetworking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StandardCyborgNetworking.h; sourceTree = "<group>"; };
 		76E7E14021E95C140038C9E0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		76E7E14721E95C590038C9E0 /* ServerUserOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerUserOperations.swift; sourceTree = "<group>"; };
-		76E7E14821E95C5A0038C9E0 /* MappableServerScan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappableServerScan.swift; sourceTree = "<group>"; };
 		76E7E14921E95C5A0038C9E0 /* ServerAPIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerAPIClient.swift; sourceTree = "<group>"; };
 		76E7E14A21E95C5A0038C9E0 /* MD5.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MD5.swift; sourceTree = "<group>"; };
 		76E7E14B21E95C5A0038C9E0 /* DefaultServerAPIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultServerAPIClient.swift; sourceTree = "<group>"; };
 		76E7E14C21E95C5A0038C9E0 /* ServerSyncEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerSyncEngine.swift; sourceTree = "<group>"; };
 		76E7E14D21E95C5A0038C9E0 /* ServerScanOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerScanOperations.swift; sourceTree = "<group>"; };
-		76E7E14E21E95C5A0038C9E0 /* MappableServerUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappableServerUser.swift; sourceTree = "<group>"; };
 		76E7E14F21E95C5A0038C9E0 /* ServerCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerCredentials.swift; sourceTree = "<group>"; };
 		76E7E15021E95C5A0038C9E0 /* DateTimeTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateTimeTransform.swift; sourceTree = "<group>"; };
+		A0C582DC22D553D70090FF6A /* ServerAccessToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerAccessToken.swift; sourceTree = "<group>"; };
+		A0C582DE22D553E10090FF6A /* ServerScanAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerScanAttachment.swift; sourceTree = "<group>"; };
+		A0C582E022D553E10090FF6A /* ServerTeam.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerTeam.swift; sourceTree = "<group>"; };
+		A0C582E422D553EC0090FF6A /* ServerScan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerScan.swift; sourceTree = "<group>"; };
+		A0C582E622D553F90090FF6A /* Coding+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Coding+Util.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,10 +74,13 @@
 		76122BEF21ED03CA00D887DF /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				A0C582DC22D553D70090FF6A /* ServerAccessToken.swift */,
 				76E7E14F21E95C5A0038C9E0 /* ServerCredentials.swift */,
-				76122BE921EC2AFD00D887DF /* ServerUser.swift */,
 				76122BEB21EC2B3A00D887DF /* ServerCustomer.swift */,
-				76122BED21EC32F200D887DF /* ServerScan.swift */,
+				A0C582E422D553EC0090FF6A /* ServerScan.swift */,
+				A0C582DE22D553E10090FF6A /* ServerScanAttachment.swift */,
+				A0C582E022D553E10090FF6A /* ServerTeam.swift */,
+				76122BE921EC2AFD00D887DF /* ServerUser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -91,19 +96,10 @@
 			path = Operations;
 			sourceTree = "<group>";
 		};
-		76122BF321ED080400D887DF /* MappableModel */ = {
-			isa = PBXGroup;
-			children = (
-				76E7E14E21E95C5A0038C9E0 /* MappableServerUser.swift */,
-				76122BF521ED087300D887DF /* MappableServerCustomer.swift */,
-				76E7E14821E95C5A0038C9E0 /* MappableServerScan.swift */,
-			);
-			path = MappableModel;
-			sourceTree = "<group>";
-		};
 		76122BF421ED081300D887DF /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				A0C582E622D553F90090FF6A /* Coding+Util.swift */,
 				76E7E15021E95C5A0038C9E0 /* DateTimeTransform.swift */,
 				76E7E14A21E95C5A0038C9E0 /* MD5.swift */,
 			);
@@ -144,7 +140,6 @@
 				76E7E14921E95C5A0038C9E0 /* ServerAPIClient.swift */,
 				76E7E14B21E95C5A0038C9E0 /* DefaultServerAPIClient.swift */,
 				76122BEF21ED03CA00D887DF /* Model */,
-				76122BF321ED080400D887DF /* MappableModel */,
 				76122BF021ED03F700D887DF /* Operations */,
 				76122BF421ED081300D887DF /* Helpers */,
 				76E7E13F21E95C140038C9E0 /* StandardCyborgNetworking.h */,
@@ -233,20 +228,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A0C582E122D553E10090FF6A /* ServerScanAttachment.swift in Sources */,
 				76E7E15321E95C5B0038C9E0 /* ServerAPIClient.swift in Sources */,
-				76122BF621ED087300D887DF /* MappableServerCustomer.swift in Sources */,
 				76122BF221ED041500D887DF /* ServerOperationError.swift in Sources */,
 				76E7E15621E95C5B0038C9E0 /* ServerSyncEngine.swift in Sources */,
 				76E7E15721E95C5B0038C9E0 /* ServerScanOperations.swift in Sources */,
 				76122BEA21EC2AFD00D887DF /* ServerUser.swift in Sources */,
 				76E7E15521E95C5B0038C9E0 /* DefaultServerAPIClient.swift in Sources */,
-				76122BEE21EC32F200D887DF /* ServerScan.swift in Sources */,
-				76E7E15221E95C5B0038C9E0 /* MappableServerScan.swift in Sources */,
+				A0C582E522D553EC0090FF6A /* ServerScan.swift in Sources */,
+				A0C582E322D553E10090FF6A /* ServerTeam.swift in Sources */,
+				A0C582E722D553F90090FF6A /* Coding+Util.swift in Sources */,
 				76E7E15921E95C5B0038C9E0 /* ServerCredentials.swift in Sources */,
 				76E7E15A21E95C5B0038C9E0 /* DateTimeTransform.swift in Sources */,
+				A0C582DD22D553D70090FF6A /* ServerAccessToken.swift in Sources */,
 				76122BEC21EC2B3A00D887DF /* ServerCustomer.swift in Sources */,
 				76E7E15421E95C5B0038C9E0 /* MD5.swift in Sources */,
-				76E7E15821E95C5B0038C9E0 /* MappableServerUser.swift in Sources */,
 				76E7E15121E95C5B0038C9E0 /* ServerUserOperations.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Helpers/Coding+Util.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Helpers/Coding+Util.swift
@@ -1,0 +1,168 @@
+//
+//
+// Adapted from:
+//
+// Original: https://gist.github.com/loudmouth/332e8d89d8de2c1eaf81875cfcd22e24
+// Adds encoding: https://github.com/3D4Medical/glTFSceneKit/blob/master/Sources/glTFSceneKit/GLTF/JSONCodingKeys.swift
+// Adds fix for null inside arrays causing infinite loop: https://gist.github.com/loudmouth/332e8d89d8de2c1eaf81875cfcd22e24#gistcomment-2807855
+//
+import Foundation
+import UIKit
+
+struct JSONCodingKeys: CodingKey {
+    var stringValue: String
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    var intValue: Int?
+
+    init?(intValue: Int) {
+        self.init(stringValue: "\(intValue)")
+        self.intValue = intValue
+    }
+}
+
+extension KeyedDecodingContainer {
+    func decode(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any] {
+        let container = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        return try container.decode(type)
+    }
+
+    func decode(_ type: [Any].Type, forKey key: K) throws -> [Any] {
+        var container = try self.nestedUnkeyedContainer(forKey: key)
+        return try container.decode(type)
+    }
+
+    func decode(_ type: [String: Any].Type) throws -> [String: Any] {
+        var dictionary = [String: Any]()
+
+        for key in allKeys {
+            if let boolValue = try? decode(Bool.self, forKey: key) {
+                dictionary[key.stringValue] = boolValue
+            } else if let stringValue = try? decode(String.self, forKey: key) {
+                dictionary[key.stringValue] = stringValue
+            } else if let intValue = try? decode(Int.self, forKey: key) {
+                dictionary[key.stringValue] = intValue
+            } else if let doubleValue = try? decode(Double.self, forKey: key) {
+                dictionary[key.stringValue] = doubleValue
+            } else if let nestedDictionary = try? decode([String: Any].self, forKey: key) {
+                dictionary[key.stringValue] = nestedDictionary
+            } else if let nestedArray = try? decode([Any].self, forKey: key) {
+                dictionary[key.stringValue] = nestedArray
+            }
+        }
+        return dictionary
+    }
+}
+
+extension UnkeyedDecodingContainer {
+    mutating func decode(_ type: [Any].Type) throws -> [Any] {
+        var array: [Any] = []
+
+        while isAtEnd == false {
+            let value: String? = try decode(String?.self)
+            if value == nil {
+                continue
+            }
+            if let value = try? decode(Bool.self) {
+                array.append(value)
+            } else if let value = try? decode(Int.self) {
+                array.append(value)
+            } else if let value = try? decode(Double.self) {
+                array.append(value)
+            } else if let value = try? decode(String.self) {
+                array.append(value)
+            } else if let nestedDictionary = try? decode([String: Any].self) {
+                array.append(nestedDictionary)
+            } else if let nestedArray = try? decode([Any].self) {
+                array.append(nestedArray)
+            }
+        }
+        return array
+    }
+
+    mutating func decode(_ type: [String: Any].Type) throws -> [String: Any] {
+        let nestedContainer = try self.nestedContainer(keyedBy: JSONCodingKeys.self)
+        return try nestedContainer.decode(type)
+    }
+}
+
+
+extension KeyedEncodingContainerProtocol where Key == JSONCodingKeys {
+    mutating func encode(_ value: [String: Any]) throws {
+        try value.forEach({ (key, value) in
+            let key = JSONCodingKeys(stringValue: key)
+            switch value {
+            case let value as Bool:
+                try encode(value, forKey: key)
+            case let value as Int:
+                try encode(value, forKey: key)
+            case let value as String:
+                try encode(value, forKey: key)
+            case let value as Double:
+                try encode(value, forKey: key)
+            case let value as CGFloat:
+                try encode(value, forKey: key)
+            case let value as [String: Any]:
+                try encode(value, forKey: key)
+            case let value as [Any]:
+                try encode(value, forKey: key)
+            case Optional<Any>.none:
+                try encodeNil(forKey: key)
+            default:
+                throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: codingPath + [key], debugDescription: "Invalid JSON value"))
+            }
+        })
+    }
+}
+
+extension KeyedEncodingContainerProtocol {
+    mutating func encode(_ value: [String: Any]?, forKey key: Key) throws {
+        if value != nil {
+            var container = self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+            try container.encode(value!)
+        }
+    }
+
+    mutating func encode(_ value: [Any]?, forKey key: Key) throws {
+        if value != nil {
+            var container = self.nestedUnkeyedContainer(forKey: key)
+            try container.encode(value!)
+        }
+    }
+}
+
+extension UnkeyedEncodingContainer {
+    mutating func encode(_ value: [Any]) throws {
+        try value.enumerated().forEach({ (index, value) in
+            switch value {
+            case let value as Bool:
+                try encode(value)
+            case let value as Int:
+                try encode(value)
+            case let value as String:
+                try encode(value)
+            case let value as Double:
+                try encode(value)
+            case let value as CGFloat:
+                try encode(value)
+            case let value as [String: Any]:
+                try encode(value)
+            case let value as [Any]:
+                try encode(value)
+            case Optional<Any>.none:
+                try encodeNil()
+            default:
+                let keys = JSONCodingKeys(intValue: index).map({ [ $0 ] }) ?? []
+                throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: codingPath + keys, debugDescription: "Invalid JSON value"))
+            }
+        })
+    }
+
+    mutating func encode(_ value: [String: Any]) throws {
+        var nestedContainer = self.nestedContainer(keyedBy: JSONCodingKeys.self)
+        try nestedContainer.encode(value)
+    }
+}

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Helpers/Coding+Util.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Helpers/Coding+Util.swift
@@ -1,4 +1,4 @@
-//
+// Source: https://gist.github.com/loudmouth/332e8d89d8de2c1eaf81875cfcd22e24
 //
 // Adapted from:
 //

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerAccessToken.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerAccessToken.swift
@@ -1,0 +1,18 @@
+//
+//  ServerTeam.swift
+//  StandardCyborgNetworking
+//
+//  Copyright © 2019 Standard Cyborg. All rights reserved.
+//
+import Foundation
+
+public struct ServerAccessToken: Codable {
+
+    public let accessToken: String
+    public let apiKey: String
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken = "Access-Token"
+        case apiKey = "Api-Key"
+    }
+}

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerCredentials.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerCredentials.swift
@@ -7,72 +7,171 @@
 
 import Foundation
 
+fileprivate let MinimumSecondsToExpiration: TimeInterval = 2 * 60 * 60 // 2 hours
+
+
 // These credentials are specific to interfacing with the Standard Cyborg server
 // They're effectively two-legged OAuth2
-struct ServerCredentials: Codable {
-    
-    private static let MinimumSecondsToExpiration: TimeInterval = 2 * 60 * 60 // 2 hours
-    
-    var accessToken: String?
-    var client: String?
-    var expiry: String?
-    var tokenType: String?
-    var uid: String?
-    
-    init() {
-        load()
+
+// Protocol for persistence is broken out from ServerCredentials so we aren't limited to using ServerCredentials
+// only as a generic constraint.
+protocol ServerCredentialPersistence: Codable {
+    static var defaultsKey: String { get }
+
+    static func fromDefaults() -> Self?
+    static func saveToDefaults(credentials: Self)
+    static func invalidate()
+}
+
+extension ServerCredentialPersistence {
+    static func fromDefaults() -> Self? {
+        guard let data = UserDefaults.standard.data(forKey: Self.defaultsKey) else { return nil }
+        return try! JSONDecoder().decode(Self.self, from: data)
     }
-    
-    mutating func load() {
-        let defaults = UserDefaults.standard
-        
-        // DEV: To make things easy on ourselves, we use the response headers as keys
-        accessToken = defaults.string(forKey: ResponseHeader.accessToken.defaultsKey)
-        client = defaults.string(forKey: ResponseHeader.client.defaultsKey)
-        expiry = defaults.string(forKey: ResponseHeader.expiry.defaultsKey)
-        tokenType = defaults.string(forKey: ResponseHeader.tokenType.defaultsKey)
-        uid = defaults.string(forKey: ResponseHeader.uid.defaultsKey)
+
+    static func saveToDefaults(credentials: Self) {
+        let data = try! JSONEncoder().encode(credentials)
+        UserDefaults.standard.set(data, forKey: Self.defaultsKey)
     }
-    
-    func persist() {
-        let defaults = UserDefaults.standard
-        
-        defaults.set(accessToken, forKey: ResponseHeader.accessToken.defaultsKey)
-        defaults.set(client, forKey: ResponseHeader.client.defaultsKey)
-        defaults.set(expiry, forKey: ResponseHeader.expiry.defaultsKey)
-        defaults.set(tokenType, forKey: ResponseHeader.tokenType.defaultsKey)
-        defaults.set(uid, forKey: ResponseHeader.uid.defaultsKey)
+
+    static func invalidate() {
+        UserDefaults.standard.set(nil, forKey: Self.defaultsKey)
     }
-    
-    mutating func invalidate() {
-        accessToken = nil
-        client = nil
-        expiry = nil
-        tokenType = nil
-        uid = nil
-        
-        persist()
-    }
-    
+}
+
+protocol ServerCredentials: Codable {
+    var accessToken: String { get }
+    var isExpired: Bool { get }
+    var isValid: Bool { get }
+
+    var headerValues: [String : String] { get }
+    mutating func updateAndPersistFromResponseHeaders(_ responseHeaders: [AnyHashable: Any])
+}
+
+
+extension ServerCredentials {
     var isValid: Bool {
-        guard expiry != nil, uid != nil && expiry != nil && client != nil && tokenType != nil && accessToken != nil else {
-            return false
-        }
-        
         return !isExpired
     }
-    
+}
+
+struct PersonalCredentials: ServerCredentials, ServerCredentialPersistence {
+    static var defaultsKey: String { return "PersonalCredentials" }
+
+    var expiry: String
+    var tokenType: String
+    var accessToken: String
+    var client: String
+    var uid: String
+
     var isExpired: Bool {
-        guard let expiryString = expiry else {
-            return false
-        }
-        
         let nowEpochSeconds = Date().timeIntervalSince1970
-        let secondsRemaining = (expiryString as NSString).doubleValue - nowEpochSeconds
-        
-        return secondsRemaining < ServerCredentials.MinimumSecondsToExpiration
+        let secondsRemaining = (expiry as NSString).doubleValue - nowEpochSeconds
+
+        return secondsRemaining < MinimumSecondsToExpiration
     }
-    
+
+    var headerValues: [String : String] {
+        return [
+            ResponseHeader.accessToken.rawValue : accessToken,
+            ResponseHeader.client.rawValue      : client,
+            ResponseHeader.expiry.rawValue      : expiry,
+            ResponseHeader.tokenType.rawValue   : tokenType,
+            ResponseHeader.uid.rawValue         : uid
+        ]
+    }
+
+    static func fromDefaults() -> PersonalCredentials? {
+        // Check for our old credentials and migrate them to the new method before trying to read
+        // that from defaults.
+        if let credentialsToMigrate = _credentialsToMigrate() {
+            _clearOldCredentials()
+            return credentialsToMigrate
+        }
+
+        guard let data = UserDefaults.standard.data(forKey: defaultsKey) else { return nil }
+        return try! JSONDecoder().decode(PersonalCredentials.self, from: data)
+    }
+
+    mutating func updateAndPersistFromResponseHeaders(_ responseHeaders: [AnyHashable : Any]) {
+        guard
+            let expiry = responseHeaders[ResponseHeader.expiry.rawValue] as? String,
+            let tokenType = responseHeaders[ResponseHeader.tokenType.rawValue] as? String,
+            let accessToken = responseHeaders[ResponseHeader.accessToken.rawValue] as? String,
+            let client = responseHeaders[ResponseHeader.client.rawValue] as? String,
+            let uid = responseHeaders[ResponseHeader.uid.rawValue] as? String else {
+                print("Could not update personal credentials for response header: \(responseHeaders)")
+                return
+        }
+
+        self.expiry = expiry
+        self.tokenType = tokenType
+        self.accessToken = accessToken
+        self.client = client
+        self.uid = uid
+        PersonalCredentials.saveToDefaults(credentials: self)
+    }
+
+    // Returns nil if there aren't any credentials to migrate otherwise create an instance of personal
+    // credentials which can be migrated to the new version.
+    private static func _credentialsToMigrate() -> PersonalCredentials? {
+        let defaults = UserDefaults.standard
+        guard
+            let accessToken = defaults.string(forKey: ResponseHeader.accessToken.defaultsKey),
+            let client = defaults.string(forKey: ResponseHeader.client.defaultsKey),
+            let expiry = defaults.string(forKey: ResponseHeader.expiry.defaultsKey),
+            let tokenType = defaults.string(forKey: ResponseHeader.tokenType.defaultsKey),
+            let uid = defaults.string(forKey: ResponseHeader.uid.defaultsKey)
+        else {
+            return nil
+        }
+
+        return PersonalCredentials(expiry: expiry, tokenType: tokenType, accessToken: accessToken, client: client, uid: uid)
+    }
+
+    // Clears out the old UserDefault keys so we don't try to migrate them again.
+    private static func _clearOldCredentials() {
+        let defaults = UserDefaults.standard
+        defaults.set(nil, forKey: ResponseHeader.accessToken.defaultsKey)
+        defaults.set(nil, forKey: ResponseHeader.client.defaultsKey)
+        defaults.set(nil, forKey: ResponseHeader.expiry.defaultsKey)
+        defaults.set(nil, forKey: ResponseHeader.tokenType.defaultsKey)
+        defaults.set(nil, forKey: ResponseHeader.uid.defaultsKey)
+
+    }
+}
+
+struct TeamCredentials: ServerCredentials, ServerCredentialPersistence {
+    enum Key: String, Codable {
+        case accessToken = "Access-Token"
+        case apiKey = "Api-Key"
+    }
+    static var defaultsKey: String { return "TeamCredentials" }
+    var apiKey: String
+    var accessToken: String
+
+    var isExpired: Bool { return false }
+
+    var headerValues: [String : String] {
+        return [
+            Key.accessToken.rawValue : accessToken,
+            Key.apiKey.rawValue      : apiKey
+        ]
+    }
+
+    mutating func updateAndPersistFromResponseHeaders(_ responseHeaders: [AnyHashable : Any]) {
+        guard
+            let apiKey = responseHeaders[Key.apiKey.rawValue] as? String,
+            let accessToken = responseHeaders[Key.accessToken.rawValue] as? String
+        else {
+            print("Could not update team credentials for response header: \(responseHeaders)")
+            return
+        }
+
+        self.accessToken = accessToken
+        self.apiKey = apiKey
+        TeamCredentials.saveToDefaults(credentials: self)
+    }
 }
 
 private extension ResponseHeader {

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerScanAttachment.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerScanAttachment.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+public struct ServerScanAttachment: Codable {
+    // Upload props
+    public let fileKey: String
+    public let thumbnailKey: String?
+    public let kind: String?
+    public let publiclyDownloadable: Bool?
+    public let publiclyVisible: Bool?
+    public let metadata: [String : Any]?
+
+    // Download props
+    public let createdAt: Date?
+    public let uploadedAt: Date?
+    public let fileUrl: String?
+    public let thumbnailUrl: String?
+    public let teamUid: String?
+    public let collectionUid: String?
+
+    enum CodingKeys: String, CodingKey {
+        case fileKey, thumbnailKey, kind, publiclyDownloadable, publiclyVisible, metadata
+        case createdAt, uploadedAt, fileUrl, thumbnailUrl, teamUid, collectionUid
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try! decoder.container(keyedBy: CodingKeys.self)
+
+        fileKey                 = try! container.decode(String.self, forKey: .fileKey)
+        thumbnailKey            = try container.decodeIfPresent(String.self, forKey: .thumbnailKey)
+        kind                    = try container.decodeIfPresent(String.self, forKey: .kind)
+        publiclyDownloadable    = try container.decodeIfPresent(Bool.self, forKey: .publiclyDownloadable)
+        publiclyVisible         = try container.decodeIfPresent(Bool.self, forKey: .publiclyVisible)
+        metadata                = try container.decode([String : Any].self, forKey: .metadata)
+
+        if let createdAtString = (try? container.decodeIfPresent(String.self, forKey: .createdAt)) ?? nil {
+            createdAt = DateTimeTransform.fromString(createdAtString)
+        } else {
+            createdAt = nil
+        }
+
+        if let uploadedAtString = (try? container.decodeIfPresent(String.self, forKey: .uploadedAt)) ?? nil {
+            uploadedAt = DateTimeTransform.fromString(uploadedAtString)
+        } else {
+            uploadedAt = nil
+        }
+
+        fileUrl                 = try container.decodeIfPresent(String.self, forKey: .fileUrl)
+        thumbnailUrl            = try container.decodeIfPresent(String.self, forKey: .thumbnailUrl)
+        teamUid                 = try container.decodeIfPresent(String.self, forKey: .teamUid)
+        collectionUid           = try container.decodeIfPresent(String.self, forKey: .collectionUid)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try! container.encode(fileKey, forKey: .fileKey)
+        try? container.encodeIfPresent(thumbnailKey, forKey: .thumbnailKey)
+        try? container.encodeIfPresent(kind, forKey: .kind)
+        try? container.encodeIfPresent(publiclyDownloadable, forKey: .publiclyDownloadable)
+        try? container.encodeIfPresent(publiclyVisible, forKey: .publiclyVisible)
+        try? container.encode(metadata, forKey: .metadata)
+
+        try? container.encodeIfPresent(fileUrl, forKey: .fileUrl)
+        try? container.encodeIfPresent(thumbnailUrl, forKey: .thumbnailUrl)
+        try? container.encodeIfPresent(teamUid, forKey: .teamUid)
+        try? container.encodeIfPresent(collectionUid, forKey: .collectionUid)
+    }
+}
+

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerTeam.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerTeam.swift
@@ -12,5 +12,5 @@ public struct ServerTeam: Codable {
     public let name: String
     public let personal: Bool
     public let uid: String
-    
+
 }

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Operations/ServerUserOperations.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Operations/ServerUserOperations.swift
@@ -12,7 +12,10 @@ private struct ClientAPIPath {
     static let authSignUp = "auth"
     static let authSignIn = "auth/sign_in"
     static let authSignOut = "auth/sign_out"
+    static let authGenerateAccessToken = "auth/generate_access_token"
 }
+
+
 
 
 public struct ServerSignUpOperation {
@@ -41,9 +44,9 @@ public struct ServerSignUpOperation {
         let url = apiClient.buildAPIURL(for: ClientAPIPath.authSignUp)
 
         apiClient.performJSONOperation(withURL: url,
-                                            httpMethod: .POST,
-                                            httpBodyDict: postDictionary,
-                                            responseObjectRootKey: "user")
+                                       httpMethod: .POST,
+                                       httpBodyDict: postDictionary,
+                                       responseObjectRootKey: "user")
         { (result: Result<ServerUser>) in
             var modifiedResult = result
             if case var .success(user) = result {
@@ -83,9 +86,9 @@ public struct ServerSignInOperation {
         ]
         let url = apiClient.buildAPIURL(for: ClientAPIPath.authSignIn)
         apiClient.performJSONOperation(withURL: url,
-                                            httpMethod: .POST,
-                                            httpBodyDict: postDictionary,
-                                            responseObjectRootKey: "user")
+                                       httpMethod: .POST,
+                                       httpBodyDict: postDictionary,
+                                       responseObjectRootKey: "user")
         { (result: Result<ServerUser>) in
             if case let .success(user) = result {
                 self.dataSource.updateUser(user)
@@ -126,3 +129,84 @@ public struct ServerSignOutOperation {
     }
     
 }
+
+public struct ServerGenerateAccessTokenOperation {
+
+    let dataSource: ServerSyncEngineLocalDataSource
+    let apiClient: ServerAPIClient
+    let apiKey: String
+
+    public init(dataSource: ServerSyncEngineLocalDataSource, apiClient: ServerAPIClient, apiKey: String) {
+        self.dataSource = dataSource
+        self.apiClient = apiClient
+        self.apiKey = apiKey
+    }
+
+    public func perform(_ completion: @escaping (Result<ServerAccessToken>) -> Void) {
+        let postDictionary = [
+            "api_key": apiKey,
+        ]
+        let url = apiClient.buildAPIURL(for: ClientAPIPath.authGenerateAccessToken)
+        apiClient.performJSONOperation(withURL: url,
+                                       httpMethod: .POST,
+                                       httpBodyDict: postDictionary,
+                                       responseObjectRootKey: nil,
+                                       completion: completion)
+    }
+}
+
+
+public struct ServerTeamSignInOperation {
+
+    let dataSource: ServerSyncEngineLocalDataSource
+    let apiClient: ServerAPIClient
+    let email: String
+    let password: String
+    let apiKey: String  // read from info.plist
+
+    public init(dataSource: ServerSyncEngineLocalDataSource, apiClient: ServerAPIClient, email: String, password: String) {
+        self.dataSource = dataSource
+        self.apiClient = apiClient
+        self.email = email
+        self.password = password
+
+        guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "SC_API_KEY") as? String else {
+            fatalError("SC_API_KEY not set in info.plist.")
+        }
+
+        self.apiKey = apiKey
+    }
+
+    public func perform(_ completion: @escaping (Result<(ServerUser, ServerAccessToken)>) -> Void) {
+        let signInOperation = ServerSignInOperation(dataSource: dataSource, apiClient: apiClient, email: email, password: password)
+        let accessTokenOperation = ServerGenerateAccessTokenOperation(dataSource: dataSource, apiClient: apiClient, apiKey: apiKey)
+
+        // NOTE: If we end up having more methods like this, the internals using PromiseKit (or Combine
+        // if we get this to iOS 13+) should be exposed to make composing these async operations
+        // more straightforward.
+        // For a single method we can tolerate reading a small async pyramid.
+        // Internally the operation will see an Access-Token in the body of the response and update our credentials
+        // object with that value (meaning all future operations will be authenticated with that particular team).
+        signInOperation.perform { signInResult in
+            switch signInResult {
+            case .success(let user):
+                accessTokenOperation.perform { accessTokenResult in
+                    switch accessTokenResult {
+                    case .success(let token):
+                        completion(.success((user, token)))
+                    case .failure(let error):
+                        self.dataSource.resetUser()
+                        self.apiClient.invalidateCredentials()
+                        completion(.failure(error))
+                    }
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+
+
+

--- a/StandardCyborgNetworking/StandardCyborgNetworking/ServerAPIClient.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/ServerAPIClient.swift
@@ -87,23 +87,7 @@ public protocol ServerAPIClient {
 }
 
 extension ServerCredentials {
-    
-    mutating func updateFromResponseHeaders(_ responseHeaders: [AnyHashable: Any]) {
-        accessToken  = responseHeaders[ResponseHeader.accessToken.rawValue] as? String
-        client       = responseHeaders[ResponseHeader.client.rawValue] as? String
-        expiry       = responseHeaders[ResponseHeader.expiry.rawValue] as? String
-        tokenType    = responseHeaders[ResponseHeader.tokenType.rawValue] as? String
-        uid          = responseHeaders[ResponseHeader.uid.rawValue] as? String
-        
-        persist()
-    }
-    
     func setResponseHeaders(on request: inout URLRequest) {
-        request.setValue(accessToken, forHTTPHeaderField: ResponseHeader.accessToken.rawValue)
-        request.setValue(client,      forHTTPHeaderField: ResponseHeader.client.rawValue)
-        request.setValue(expiry,      forHTTPHeaderField: ResponseHeader.expiry.rawValue)
-        request.setValue(tokenType,   forHTTPHeaderField: ResponseHeader.tokenType.rawValue)
-        request.setValue(uid,         forHTTPHeaderField: ResponseHeader.uid.rawValue)
+        headerValues.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
     }
-    
 }


### PR DESCRIPTION
_Please review after #2._

This PR updates StandardCyborgNetworking to use version 2 of the StandardCyborg API (which is necessary for supporting team-based actions).

Changes include:
- DefaultServerAPIClient now holds references to credentials for a user's personal credentials _and_ team credentials (note for now only a user can only be logged into one team at a time)
- Uses a custom extension on Codable to support generic encoding/decoding of JSON types from the API.
  - This is necessary to support the `metadata` field of `ServerScanAttachment`
- Refactors how server credentials are persisted to disk
- Fixes some issues around Codable serialization for object properties that aren't required by the API
- Updates `ServerScan` object and adds `ServerScanAttachment` model
- Removes `localURL` prop in `S3UploadInfo` so it can be used for serialization (this was a bit confusing because `localURL` wasn't ever sent to the server and was only necessary while the file was uploading).
