### PR TITLE
StandardCyborgUI, StandardCyborgNetworking: Update podspec version and tag schema

### DIFF
--- a/StandardCyborgNetworking/StandardCyborgNetworking.podspec
+++ b/StandardCyborgNetworking/StandardCyborgNetworking.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name              = "StandardCyborgNetworking"
-  s.version           = "1.3.2"
+  s.version           = "1.4.0"
   s.summary           = "Classes for interacting with the Standard Cyborg Platform networking APIs"
   s.homepage          = 'https://github.com/StandardCyborg/StandardCyborgCocoa'
   s.social_media_url  = 'https://twitter.com/StandardCyborg'
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.platform          = :ios, "12.0"
   s.swift_version     = '4.2'
   s.requires_arc      = true
-  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}" }
+  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-networking" }
   s.source_files      = "StandardCyborgNetworking/**/*.{swift}"
   s.dependency          "SSZipArchive"
   s.dependency          "PromiseKit", "~> 6.0"

--- a/StandardCyborgNetworking/StandardCyborgNetworking.podspec
+++ b/StandardCyborgNetworking/StandardCyborgNetworking.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.platform          = :ios, "12.0"
   s.swift_version     = '4.2'
   s.requires_arc      = true
-  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-networking" }
+  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-StandardCyborgNetworking" }
   s.source_files      = "StandardCyborgNetworking/**/*.{swift}"
   s.dependency          "SSZipArchive"
   s.dependency          "PromiseKit", "~> 6.0"

--- a/StandardCyborgUI/StandardCyborgUI.podspec
+++ b/StandardCyborgUI/StandardCyborgUI.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.requires_arc      = true
   s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-ui" }
   s.source_files      = "StandardCyborgUI/**/*.{h,swift,metal}"
-  s.resources         = ['StandardCyborgUI/*.scn', 'StandardCyborgUI/Assets.xcassets']
+  s.resources         = "StandardCyborgUI/**/*.{scn,xcassets}"
   s.weak_frameworks   = "StandardCyborgFusion", "QuartzCore", "CoreVideo"
   s.dependency          "StandardCyborgFusion", "~> #{s.version}"
 

--- a/StandardCyborgUI/StandardCyborgUI.podspec
+++ b/StandardCyborgUI/StandardCyborgUI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name              = "StandardCyborgUI"
-  s.version           = "1.3.4"
+  s.version           = "1.3.5"
   s.summary           = "Classes for driving and visualizing scanning using StandardCyborgFusion"
   s.homepage          = 'https://github.com/StandardCyborg/StandardCyborgCocoa'
   s.social_media_url  = 'https://twitter.com/StandardCyborg'
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.platform          = :ios, "12.0"
   s.swift_version     = '4.2'
   s.requires_arc      = true
-  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}" }
+  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-ui" }
   s.source_files      = "StandardCyborgUI/**/*.{h,swift,metal}"
   s.resources         = ['StandardCyborgUI/*.scn', 'StandardCyborgUI/Assets.xcassets']
   s.weak_frameworks   = "StandardCyborgFusion", "QuartzCore", "CoreVideo"

--- a/StandardCyborgUI/StandardCyborgUI.podspec
+++ b/StandardCyborgUI/StandardCyborgUI.podspec
@@ -26,10 +26,10 @@ Pod::Spec.new do |s|
   s.platform          = :ios, "12.0"
   s.swift_version     = '4.2'
   s.requires_arc      = true
-  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-ui" }
+  s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-StandardCyborgUI" }
   s.source_files      = "StandardCyborgUI/**/*.{h,swift,metal}"
   s.resources         = "StandardCyborgUI/**/*.{scn,xcassets}"
   s.weak_frameworks   = "StandardCyborgFusion", "QuartzCore", "CoreVideo"
-  s.dependency          "StandardCyborgFusion", "~> #{s.version}"
+  s.dependency          "StandardCyborgFusion", "~> 1.3.5-StandardCyborgFusion"
 
 end


### PR DESCRIPTION
UI => `1.3.5`: Updated patch version for recent fixes
Networking => `1.4.0`: Updated major version for API v2 support

Additionally, since the podspec `source` property is dependent on tags and we have multiple podspecs in a single repo, a suffix was added to the UI and Networking podspecs to make it possible to differentiate between versions for each tag.