### PR TITLE
Revert “Update ScanningViewController.isCameraPaused to be a derived value"

### DIFF
--- a/StandardCyborgUI/StandardCyborgUI/CameraManager.swift
+++ b/StandardCyborgUI/StandardCyborgUI/CameraManager.swift
@@ -160,9 +160,7 @@ public extension Notification.Name {
     
     /** Fixes the RGB camera's focus at the current focal distance when true */
     @objc public var isFocusLocked: Bool = false {
-        didSet {
-            guard isFocusLocked != oldValue else { return }
-            
+        didSet {            
             _focus(mode: isFocusLocked ? .locked : .continuousAutoFocus,
                    exposureMode: isFocusLocked ? .locked : .continuousAutoExposure,
                    at: CGPoint(x: 0.5, y: 0.5))

--- a/StandardCyborgUI/StandardCyborgUI/ScanningViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ScanningViewController.swift
@@ -130,12 +130,13 @@ import UIKit
     }
     
     /** To manually pause the camera output, set this to true */
-    @objc public var isCameraPaused: Bool {
-        get { return _cameraManager._captureSession.isRunning }
-        set {
-            if newValue && _cameraManager._captureSession.isRunning {
+    @objc public var isCameraPaused: Bool = false {
+        didSet {
+            guard oldValue != isCameraPaused else { return }
+            
+            if isCameraPaused {
                 _cameraManager.stopSession()
-            } else if !newValue && !_cameraManager._captureSession.isRunning {
+            } else {
                 _cameraManager.startSession(nil)
             }
         }


### PR DESCRIPTION
Turns out the management of this state is a bit more fragile than I originally thought. The underlying session is modified asynchronously meaning in some cases the _reading_ of the top-level `paused` value could be incorrect.

We’ll need to take a deeper more thoughtful dive into this in the future if we want to keep the value derived.

Also with this change we revert the `isFocusLocked` since the both changes were necessary to support my new implementation (the one we’re reverting)