### PR TITLE
Add `defaultCaptureUploadTeamKey` property to ServerUser

### DIFF
--- a/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerUser.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerUser.swift
@@ -12,16 +12,18 @@ public struct ServerUser: Codable {
     public var key: String?
     public var email: String?
     public var name: String?
+    public var defaultCaptureUploadTeamKey: String?
     public var teams: [ServerTeam]?
     
     enum CodingKeys: String, CodingKey {
-        case key = "uid", email, name, teams
+        case key = "uid", email, name, defaultCaptureUploadTeamKey, teams
     }
     
-    public init(key: String? = nil, email: String? = nil, name: String? = nil, teams: [ServerTeam]? = nil) {
+    public init(key: String? = nil, email: String? = nil, name: String? = nil, defaultCaptureUploadTeamKey: String? = nil, teams: [ServerTeam]? = nil) {
         self.key = key
         self.email = email
         self.name = name
+        self.defaultCaptureUploadTeamKey = defaultCaptureUploadTeamKey
         self.teams = teams
     }
 }


### PR DESCRIPTION
Maps to new property `default_capture_upload_team_key` defined by: https://platform.standardcyborg.com/api/docs/registration/get_me