### PR TITLE
Add `scenesLimit` and `scenesCount` props to ServerTeam object

### DIFF
--- a/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerTeam.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Model/ServerTeam.swift
@@ -16,4 +16,6 @@ public struct ServerTeam: Codable {
     public let name: String
     public let uid: String
     public let role: Role = .default
+    public let scenesLimit: Int
+    public let scenesCount: Int
 }


### PR DESCRIPTION
These props are part of the API response for a team (though they don’t appear to be in the documentation yet).