### PR TITLE
Expose AVCaptureDevice authorizationStatus information

### DIFF
--- a/StandardCyborgUI/StandardCyborgUI/CameraManager.swift
+++ b/StandardCyborgUI/StandardCyborgUI/CameraManager.swift
@@ -13,6 +13,7 @@ import UIKit
 @objc public protocol CameraManagerDelegate: AnyObject {
     func cameraDidOutput(colorBuffer: CVPixelBuffer, depthBuffer: CVPixelBuffer, depthCalibrationData: AVCameraCalibrationData)
     @objc optional func cameraManagerDidStartSession(_ manager: CameraManager)
+    @objc optional func cameraManagerDidNotStartSession(_ manager: CameraManager, result: CameraManager.SessionSetupResult)
 }
 
 public extension Notification.Name {
@@ -39,6 +40,10 @@ public extension Notification.Name {
      */
     @objc public class var isDepthCameraAvailable: Bool {
         return ARFaceTrackingConfiguration.isSupported
+    }
+    
+    @objc public class var isCameraPermissionDenied: Bool {
+        AVCaptureDevice.authorizationStatus(for: .video) == .denied
     }
     
     deinit {
@@ -114,6 +119,7 @@ public extension Notification.Name {
                     NotificationCenter.default.post(name: .CameraManagerDidStartSession, object: nil)
                 }
             case .notAuthorized, .configurationFailed:
+                self.delegate?.cameraManagerDidNotStartSession?(self, result: result)
                 break
             }
             


### PR DESCRIPTION
This PR partially exposes AVCaptureDevice’s authorizationStatus information from within CameraManager to allow consumers to react accordingly.

Until now the only way to tell outside of StandardCyborgUI whether or not camera permissions had been granted was to query AVCaptureDevice directly. We expose a getter for this value inside of CameraManager and also add a hook so we may imperatively react to the starting of a camera session failing due to a denial of camera permissions. The latter case is useful if an application wants to update its UI and direct users to Settings for granting permission immediately after the authorization request has been denied.