### PR TITLE
Add `additionalBodyParameters` prop to ServerAddSceneOperation and ServerSignUpOperation

### DIFF
--- a/StandardCyborgNetworking/StandardCyborgNetworking/Operations/ServerSceneOperations.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Operations/ServerSceneOperations.swift
@@ -57,11 +57,13 @@ public class ServerAddSceneOperation: ServerOperation {
     let thumbnailURL: URL?
     let teamKey: String?
     let metadata: [String: Any]
+    let additionalSceneParameters: [String: Any]
         
     public init(gltfURL: URL,
                 thumbnailURL: URL? = nil,
                 teamKey: String? = nil,
                 metadata: [String: Any] = [:],
+                additionalSceneParameters: [String: Any] = [:],
                 dataSource: ServerSyncEngineLocalDataSource,
                 serverAPIClient: ServerAPIClient)
     {
@@ -69,8 +71,9 @@ public class ServerAddSceneOperation: ServerOperation {
         self.thumbnailURL = thumbnailURL
         self.teamKey = teamKey
         self.metadata = metadata
+        self.additionalSceneParameters = additionalSceneParameters
         
-        for value in metadata.values {
+        for value in Array(metadata.values) + Array(additionalSceneParameters.values) {
             assert(value is Bool || value is Int || value is Float || value is Double || value is String)
         }
         
@@ -189,6 +192,9 @@ public class ServerAddSceneOperation: ServerOperation {
             var sceneVersionDict: [String: Any] = ["scenegraph_key": sceneUploadInfo.directUploadFileKey]
             sceneVersionDict["thumbnail_key"] = thumbnailUploadInfo?.directUploadFileKey
             sceneVersionDict["metadata"] = metadata
+            
+            // Merge the additional body parameters, but let those already defined take precedent.
+            sceneVersionDict.merge(additionalSceneParameters, uniquingKeysWith: { (current, _) in current })
             
             serverAPIClient.performJSONOperation(withURL: url,
                                                  httpMethod: .PUT,

--- a/StandardCyborgNetworking/StandardCyborgNetworking/Operations/ServerUserOperations.swift
+++ b/StandardCyborgNetworking/StandardCyborgNetworking/Operations/ServerUserOperations.swift
@@ -21,14 +21,17 @@ public class ServerSignUpOperation: ServerOperation {
     
     let email: String
     let password: String
+    let additionalBodyParameters: [String : Any]
     
     public init(dataSource: ServerSyncEngineLocalDataSource,
                 apiClient: ServerAPIClient,
                 email: String,
-                password: String)
+                password: String,
+                additionalBodyParameters: [String : Any] = [:])
     {
         self.email = email
         self.password = password
+        self.additionalBodyParameters = additionalBodyParameters
         super.init(dataSource: dataSource, serverAPIClient: apiClient)
     }
     
@@ -36,7 +39,8 @@ public class ServerSignUpOperation: ServerOperation {
         let postDictionary = [
             "email": email,
             "password": password
-        ]
+        ].merging(additionalBodyParameters, uniquingKeysWith: { (current, _) in current })
+        
         let url = serverAPIClient.buildAPIURL(for: ClientAPIPath.authSignUp)
 
         serverAPIClient.performJSONOperation(withURL: url,


### PR DESCRIPTION
In some cases we want to include additional parameters to these requests that aren’t explicitly defined by the constructor. We merge these parameters with the default payload deferring to the default payload when keys conflict.