### PR TITLE
StandardCyborgUI podspec fixes and ScenePreviewViewController enhancements

### DIFF
--- a/StandardCyborgUI/StandardCyborgUI.podspec
+++ b/StandardCyborgUI/StandardCyborgUI.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.requires_arc      = true
   s.source            = { :git => 'https://github.com/StandardCyborg/StandardCyborgCocoa.git', :tag => "v#{s.version}-StandardCyborgUI" }
   s.source_files      = "StandardCyborgUI/**/*.{h,m,swift,metal}"
-  s.resources         = "StandardCyborgUI/**/*.{scn,xcassets}"
+  s.resource_bundles  = { "StandardCyborgUI" => ["StandardCyborgUI/**/*.{scn,xcassets,metal}"] }
   s.weak_frameworks   = "StandardCyborgFusion", "QuartzCore", "CoreVideo"
   s.dependency          "StandardCyborgFusion"
 

--- a/StandardCyborgUI/StandardCyborgUI/Bundle+SCUI.swift
+++ b/StandardCyborgUI/StandardCyborgUI/Bundle+SCUI.swift
@@ -4,4 +4,7 @@ extension Bundle {
     // Any entity using this prop should exist in the same target as the Bundle(for:) argument otherwise its contents
     // won't be packaged correctly.
     public static let scuiBundle = Bundle(for: ShutterButton.self)
+    
+    public static let scuiResourcesBundle =
+        Bundle(url: scuiBundle.resourceURL!.appendingPathComponent("StandardCyborgUI.bundle"))!
 }

--- a/StandardCyborgUI/StandardCyborgUI/DefaultScanningViewRenderer.swift
+++ b/StandardCyborgUI/StandardCyborgUI/DefaultScanningViewRenderer.swift
@@ -21,7 +21,7 @@ public class DefaultScanningViewRenderer: ScanningViewRenderer {
     required public init(device: MTLDevice, commandQueue: MTLCommandQueue) {
         _commandQueue = commandQueue
         
-        let library = try! device.makeDefaultLibrary(bundle: Bundle(for: DefaultScanningViewRenderer.self))
+        let library = try! device.makeDefaultLibrary(bundle: Bundle.scuiResourcesBundle)
         
         _drawTextureCommandEncoder = AspectFillTextureCommandEncoder(device: device, library: library)
         _pointCloudRenderer = PointCloudCommandEncoder(device: device, library: library)

--- a/StandardCyborgUI/StandardCyborgUI/PointCloudCommandEncoder.swift
+++ b/StandardCyborgUI/StandardCyborgUI/PointCloudCommandEncoder.swift
@@ -55,7 +55,7 @@ public class PointCloudCommandEncoder {
         _device = device
         
         let textureLoader = MTKTextureLoader(device: _device)
-        let bundle = Bundle(for: PointCloudCommandEncoder.self)
+        let bundle = Bundle.scuiResourcesBundle
         /*
         guard let matcapURL = bundle.url(forResource: "matcap", withExtension: "png") else {
             fatalError("Couldn't find matcap.png in \(bundle)")

--- a/StandardCyborgUI/StandardCyborgUI/ScanningViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ScanningViewController.swift
@@ -388,7 +388,7 @@ import UIKit
         _mirrorModeLabel.textAlignment = NSTextAlignment.center
         _mirrorModeLabel.numberOfLines = 2
         _mirrorModeButton.addTarget(self, action: #selector(toggleMirrorMode(_:)), for: UIControl.Event.touchUpInside)
-        _mirrorModeButton.setImage(UIImage(named: "FlipCamera", in: Bundle(for: ScanningViewController.self), compatibleWith: nil)!, for: UIControl.State.normal)
+        _mirrorModeButton.setImage(UIImage(named: "FlipCamera", in: Bundle.scuiResourcesBundle, compatibleWith: nil)!, for: UIControl.State.normal)
         
         _countdownLabel.textColor = UIColor.white
         _countdownLabel.textAlignment = NSTextAlignment.center
@@ -401,7 +401,7 @@ import UIKit
         _scanFailedLabel.backgroundColor = UIColor(white: 1.0, alpha: 0.8)
         _scanFailedLabel.isHidden = true
         
-        dismissButton.setImage(UIImage(named: "Dismiss", in: Bundle.scuiBundle, compatibleWith: nil), for: UIControl.State.normal)
+        dismissButton.setImage(UIImage(named: "Dismiss", in: Bundle.scuiResourcesBundle, compatibleWith: nil), for: UIControl.State.normal)
         dismissButton.addTarget(self, action: #selector(dismissTapped(_:)), for: UIControl.Event.touchUpInside)
         shutterButton.addTarget(self, action: #selector(shutterTapped(_:)), for: UIControl.Event.touchUpInside)
         

--- a/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
@@ -152,7 +152,7 @@ import UIKit
         }
         
         let progressViewCenter = CGPoint(x: view.center.x, y: view.safeAreaInsets.top + (meshingProgressView.frame.height / 2) + 12)
-        meshingProgressView.bounds = CGRect(x: 0, y: 0, width: 40, height: 8)
+        meshingProgressView.bounds = CGRect(x: 0, y: 0, width: view.bounds.width - 2 * buttonSpacing, height: 8)
         meshingProgressView.center = progressViewCenter
     }
     

--- a/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
@@ -59,7 +59,7 @@ import UIKit
     
     /** Owners may mutate this view to change its appearance and add nodes to its scene */
     @objc public let sceneView: SCNView = {
-        guard let sceneURL = Bundle(for: ScenePreviewViewController.self).url(forResource: "ScenePreviewViewController", withExtension: "scn") else {
+        guard let sceneURL = Bundle.scuiResourcesBundle.url(forResource: "ScenePreviewViewController", withExtension: "scn") else {
             fatalError("Could not find scene file for ScenePreviewViewController")
         }
         

--- a/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
@@ -29,6 +29,9 @@ import UIKit
     /** Gives us a hook to capture the renderedPointCloudImage separate from when it may be set. */
     @objc public var onRenderedSceneImageUpdated: ((UIImage) -> Void)?
     
+    /** Gives us a hook to know the textured mesh is generated. */
+    @objc public var onTexturedMeshGenerated: ((SCMesh) -> Void)?
+    
     override public var preferredStatusBarStyle: UIStatusBarStyle { .default }
     
     /**
@@ -191,6 +194,7 @@ import UIKit
                 case .success(let mesh):
                     self.scScene = SCScene(pointCloud: pointCloud, mesh: mesh)
                     self._constructScene(withSCScene: self.scScene)
+                    self.onTexturedMeshGenerated?(mesh)
                     
                 case .failure(let error):
                     print("Error processing mesh: \(String(describing: error.localizedDescription))")

--- a/StandardCyborgUI/StandardCyborgUI/ShutterButton.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ShutterButton.swift
@@ -45,9 +45,9 @@ import UIKit
     // MARK: - Private
     
     private var _imageForState: [ShutterButtonState: UIImage] = [
-        .default: UIImage(named: "ShutterButton", in: Bundle.scuiBundle, compatibleWith: nil)!,
-        .countdown: UIImage(named: "ShutterButton-Selected", in: Bundle.scuiBundle, compatibleWith: nil)!,
-        .scanning: UIImage(named: "ShutterButton-Recording", in: Bundle.scuiBundle, compatibleWith: nil)!,
+        .default: UIImage(named: "ShutterButton", in: Bundle.scuiResourcesBundle, compatibleWith: nil)!,
+        .countdown: UIImage(named: "ShutterButton-Selected", in: Bundle.scuiResourcesBundle, compatibleWith: nil)!,
+        .scanning: UIImage(named: "ShutterButton-Recording", in: Bundle.scuiResourcesBundle, compatibleWith: nil)!,
     ]
     
     private func _updateButtonImage() {


### PR DESCRIPTION
When including StandardCyborgUI in a project that already has an xcassets bundle, I was hitting this build error

> Multiple commands produce '/Users/me/Library/Developer/Xcode/DerivedData/Build/Products/Debug/MyApp.app/Assets.car':
> 1) Target 'MyApp' (project 'MyApp') has compile command with input '/Users/me/Source/MyApp/MyApp/Images.xcassets'
> 2) That command depends on command in Target 'MyApp' (project 'MyApp'): script phase “[CP] Copy Pods Resources”

The fix is to move resources into a resources bundle and update the bundle loading code accordingly. This change causes CocoaPods to generate a bundle called StandardCyborgUI.bundle when compiling the pod, into which the scenes, assets, and compiled Metal library are included.


Along the way, this makes a couple improvements to the `ScenePreviewViewController`.