### PR TITLE
StandardCyborgUI: add `processMesh` method with coloringStrategy argument

### DIFF
--- a/StandardCyborgUI/StandardCyborgUI.podspec
+++ b/StandardCyborgUI/StandardCyborgUI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name              = "StandardCyborgUI"
-  s.version           = "1.7.2"
+  s.version           = "1.7.3"
   s.summary           = "Classes for driving and visualizing scanning using StandardCyborgFusion"
   s.homepage          = 'https://github.com/StandardCyborg/StandardCyborgCocoa'
   s.social_media_url  = 'https://twitter.com/StandardCyborg'

--- a/StandardCyborgUI/StandardCyborgUI/SCMeshingHelper.swift
+++ b/StandardCyborgUI/StandardCyborgUI/SCMeshingHelper.swift
@@ -28,10 +28,15 @@ public class SCMeshingHelper {
     }
      
     func processMesh(onMeshStatusUpdate: @escaping ((Status) -> Void)) {
+        processMesh(coloringStrategy: .vertex, onMeshStatusUpdate: onMeshStatusUpdate)
+    }
+    
+    func processMesh(coloringStrategy: SCMeshColoringStrategy, onMeshStatusUpdate: @escaping ((Status) -> Void)) {
         meshTexturing.reconstructMesh(
             pointCloud: pointCloud,
             textureResolution: 2048,
             meshingParameters: meshingParameters,
+            coloringStrategy: coloringStrategy,
             progress: { (progress, stop) in
                 onMeshStatusUpdate(.inProgress(progress))
             },

--- a/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
+++ b/StandardCyborgUI/StandardCyborgUI/ScenePreviewViewController.swift
@@ -14,6 +14,7 @@ import UIKit
     @objc public private(set) var scScene: SCScene
     @objc private var meshTexturing: SCMeshTexturing?
     @objc private var landmarks: Set<SCLandmark3D>?
+    @objc private var coloringStrategy: SCMeshColoringStrategy = .vertex
     
     /** A snapshot of the scene as-rendered, which becomes available
         as soon as the view controller's view appears. If meshing is enabled this
@@ -43,6 +44,21 @@ import UIKit
      */
     @objc public init(pointCloud: SCPointCloud, meshTexturing: SCMeshTexturing?, landmarks: Set<SCLandmark3D>?) {
         self.scScene = SCScene(pointCloud: pointCloud, mesh: nil)
+        self.meshTexturing = meshTexturing
+        self.landmarks = landmarks
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    /**
+     Create an instance of ScenePreviewViewController with a pointCloud, meshColoringStrategy, meshTexturing instance, and landmarks.
+     
+     You can get the correct instance of `meshTexturing` from `ScanningViewController.meshTexturing`
+     after scanning has completed in the delegate callback `ScanningViewController(_ controller:didScan pointCloud)`
+     */
+    @objc public init(pointCloud: SCPointCloud, meshColoringStrategy: SCMeshColoringStrategy, meshTexturing: SCMeshTexturing, landmarks: Set<SCLandmark3D>?) {
+        self.scScene = SCScene(pointCloud: pointCloud, mesh: nil)
+        self.coloringStrategy = meshColoringStrategy
         self.meshTexturing = meshTexturing
         self.landmarks = landmarks
         
@@ -216,7 +232,7 @@ import UIKit
         meshingProgressView.setProgress(0, animated: false)
         
         _meshingHelper = SCMeshingHelper(pointCloud: pointCloud, meshTexturing: meshTexturing)
-        _meshingHelper?.processMesh { meshingStatus in
+        _meshingHelper?.processMesh(coloringStrategy: coloringStrategy) { meshingStatus in
             DispatchQueue.main.async {
                 switch meshingStatus {
                 case .inProgress(let progress):


### PR DESCRIPTION
Addresses the color strategy change to the argument list for `SCMeshTexturing.reconstructMesh` by adding a new method which takes the coloringStrategy as an argument. The original method defaults to `vertex` to preserve backwards compatibility.